### PR TITLE
Move Yard into documentation task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake', '~> 11.1', :group => [:development, :test]
+gem 'rake', '~> 12.2', '>= 12.2.1', group: [:development, :test]
 
 group :development do
   gem 'flay', '~> 2.6'

--- a/Rakefile
+++ b/Rakefile
@@ -27,12 +27,6 @@ RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
 end
 
-require 'yard'
-YARD::Rake::YardocTask.new do |ydoc|
-  ydoc.options += ['-o', 'ydoc']
-  ydoc.name = 'ydoc'
-end
-
 # Testing.
 # require 'rake/testtask'
 # Rake::TestTask.new do |t|
@@ -43,7 +37,7 @@ end
 # end
 
 namespace :test do
-  interpreter = 'ruby -rubygems -I lib -I test'
+  interpreter = 'ruby -I lib -I test'
   task :local do
     sh "#{interpreter} test/local_*"
   end
@@ -78,7 +72,13 @@ task :v do
 end
 
 desc 'Document the code using Yard and RDoc.'
-task doc: [:clobber, :rdoc, :ydoc]
+task doc: [:clobber, :rdoc, :ydoc] do
+  require 'yard'
+  YARD::Rake::YardocTask.new do |ydoc|
+    ydoc.options += ['-o', 'ydoc']
+    ydoc.name = 'ydoc'
+  end
+end
 
 desc 'Release the library.'
 task release: [:tag, :build, :publish] do


### PR DESCRIPTION
the yard gem is only loaded in the development environment.
In our `Rakefile` initializer we expect it to be there. On travis ci
only the
test environment is load. This cause the now the `Rakefile` to fail on
any task
as the `yard` can't be required:.
- update Rake to `12.2`
- remove old `-rubygems` parameter as of ruby `2.0` [this is not needed
anymore](http://guides.rubygems.org/make-your-own-gem/#your-first-gem)

close #8 